### PR TITLE
fix: delete legacy information in Realm Database

### DIFF
--- a/GitHubSearch/Services/RepositoryService.swift
+++ b/GitHubSearch/Services/RepositoryService.swift
@@ -49,6 +49,9 @@ final class RepositoryService {
 
     func deleteRepository(_ repository: Repository) {
         if let object = realmService.fetch(ofType: Repository.self, forPrimaryKey: repository.fullName) {
+            if let owner = object.owner {
+                realmService.delete(owner)
+            }
             realmService.delete(object)
         }
     }


### PR DESCRIPTION
When we delete "Repository" object from Realm, it
doesn't automatically delete the "Owner" associated with it.